### PR TITLE
1D line extraction from 2D images

### DIFF
--- a/src/torch_fourier_slice/__init__.py
+++ b/src/torch_fourier_slice/__init__.py
@@ -9,7 +9,7 @@ except PackageNotFoundError:
 __author__ = "Alister Burt"
 __email__ = "alisterburt@gmail.com"
 
-from .project import project_3d_to_2d
+from .project import project_3d_to_2d, project_2d_to_1d
 from .backproject import backproject_2d_to_3d
 from .slice_insertion import insert_central_slices_rfft_3d
 from .slice_extraction import extract_central_slices_rfft_3d

--- a/src/torch_fourier_slice/dft_utils.py
+++ b/src/torch_fourier_slice/dft_utils.py
@@ -38,13 +38,7 @@ def fftshift_3d(input: torch.Tensor, rfft: bool) -> torch.Tensor:
     if rfft is False:
         output = torch.fft.fftshift(input, dim=(-3, -2, -1))
     else:
-        output = torch.fft.fftshift(
-            input,
-            dim=(
-                -3,
-                -2,
-            ),
-        )
+        output = torch.fft.fftshift(input, dim=(-3,-2,))
     return output
 
 
@@ -52,13 +46,7 @@ def ifftshift_3d(input: torch.Tensor, rfft: bool) -> torch.Tensor:
     if rfft is False:
         output = torch.fft.ifftshift(input, dim=(-3, -2, -1))
     else:
-        output = torch.fft.ifftshift(
-            input,
-            dim=(
-                -3,
-                -2,
-            ),
-        )
+        output = torch.fft.ifftshift(input, dim=(-3, -2,))
     return output
 
 

--- a/src/torch_fourier_slice/dft_utils.py
+++ b/src/torch_fourier_slice/dft_utils.py
@@ -38,7 +38,7 @@ def fftshift_3d(input: torch.Tensor, rfft: bool) -> torch.Tensor:
     if rfft is False:
         output = torch.fft.fftshift(input, dim=(-3, -2, -1))
     else:
-        output = torch.fft.fftshift(input, dim=(-3,-2,))
+        output = torch.fft.fftshift(input, dim=(-3, -2,))
     return output
 
 

--- a/src/torch_fourier_slice/dft_utils.py
+++ b/src/torch_fourier_slice/dft_utils.py
@@ -108,7 +108,7 @@ def dft_center(
     fft_center = torch.zeros(size=(len(image_shape),), device=device)
     image_shape = torch.as_tensor(image_shape).float()
     if rfft is True:
-        image_shape = torch.tensor(rfft_shape(image_shape))
+        image_shape = torch.tensor(rfft_shape(image_shape), device=device)
     if fftshifted is True:
         fft_center = torch.divide(image_shape, 2, rounding_mode="floor")
     if rfft is True:

--- a/src/torch_fourier_slice/dft_utils.py
+++ b/src/torch_fourier_slice/dft_utils.py
@@ -38,7 +38,13 @@ def fftshift_3d(input: torch.Tensor, rfft: bool) -> torch.Tensor:
     if rfft is False:
         output = torch.fft.fftshift(input, dim=(-3, -2, -1))
     else:
-        output = torch.fft.fftshift(input, dim=(-3, -2,))
+        output = torch.fft.fftshift(
+            input,
+            dim=(
+                -3,
+                -2,
+            ),
+        )
     return output
 
 
@@ -46,7 +52,13 @@ def ifftshift_3d(input: torch.Tensor, rfft: bool) -> torch.Tensor:
     if rfft is False:
         output = torch.fft.ifftshift(input, dim=(-3, -2, -1))
     else:
-        output = torch.fft.ifftshift(input, dim=(-3, -2,))
+        output = torch.fft.ifftshift(
+            input,
+            dim=(
+                -3,
+                -2,
+            ),
+        )
     return output
 
 
@@ -98,7 +110,7 @@ def dft_center(
     if rfft is True:
         image_shape = torch.tensor(rfft_shape(image_shape))
     if fftshifted is True:
-        fft_center = torch.divide(image_shape, 2, rounding_mode='floor')
+        fft_center = torch.divide(image_shape, 2, rounding_mode="floor")
     if rfft is True:
         fft_center[-1] = 0
     return fft_center.long()

--- a/src/torch_fourier_slice/dft_utils.py
+++ b/src/torch_fourier_slice/dft_utils.py
@@ -10,6 +10,14 @@ def rfft_shape(input_shape: Sequence[int]) -> Tuple[int, ...]:
     return tuple(rfft_shape)
 
 
+def fftshift_1d(input: torch.Tensor, rfft: bool) -> torch.Tensor:
+    if rfft is False:
+        output = torch.fft.fftshift(input, dim=(-1))
+    else:
+        output = input
+    return output
+
+
 def fftshift_2d(input: torch.Tensor, rfft: bool) -> torch.Tensor:
     if rfft is False:
         output = torch.fft.fftshift(input, dim=(-2, -1))

--- a/src/torch_fourier_slice/grids/__init__.py
+++ b/src/torch_fourier_slice/grids/__init__.py
@@ -1,2 +1,2 @@
-from .central_slice_fftfreq_grid import central_slice_fftfreq_grid
 from .central_line_fftfreq_grid import central_line_fftfreq_grid
+from .central_slice_fftfreq_grid import central_slice_fftfreq_grid

--- a/src/torch_fourier_slice/grids/__init__.py
+++ b/src/torch_fourier_slice/grids/__init__.py
@@ -1,1 +1,2 @@
 from .central_slice_fftfreq_grid import central_slice_fftfreq_grid
+from .central_line_fftfreq_grid import central_line_fftfreq_grid

--- a/src/torch_fourier_slice/grids/central_line_fftfreq_grid.py
+++ b/src/torch_fourier_slice/grids/central_line_fftfreq_grid.py
@@ -1,7 +1,7 @@
 import einops
 import torch
 
-from ..dft_utils import rfft_shape, fftshift_1d
+from ..dft_utils import fftshift_1d, rfft_shape
 
 
 def central_line_fftfreq_grid(
@@ -23,11 +23,11 @@ def central_line_fftfreq_grid(
         zeros = torch.zeros(size=rfft_shape((w,)), dtype=grid.dtype, device=device)
     else:
         zeros = torch.zeros(size=(w,), dtype=grid.dtype, device=device)
-    central_slice_grid, _ = einops.pack([zeros, grid], pattern='w *')  # (w, 2)
+    central_slice_grid, _ = einops.pack([zeros, grid], pattern="w *")  # (w, 2)
 
     # fftshift if requested
     if fftshift is True:
-        central_slice_grid = einops.rearrange(central_slice_grid, 'w freq -> freq w')
+        central_slice_grid = einops.rearrange(central_slice_grid, "w freq -> freq w")
         central_slice_grid = fftshift_1d(central_slice_grid, rfft=rfft)
-        central_slice_grid = einops.rearrange(central_slice_grid, 'freq w -> w freq')
+        central_slice_grid = einops.rearrange(central_slice_grid, "freq w -> w freq")
     return central_slice_grid

--- a/src/torch_fourier_slice/grids/central_line_fftfreq_grid.py
+++ b/src/torch_fourier_slice/grids/central_line_fftfreq_grid.py
@@ -1,0 +1,33 @@
+import einops
+import torch
+
+from ..dft_utils import rfft_shape, fftshift_1d
+
+
+def central_line_fftfreq_grid(
+    image_shape: tuple[int, int],
+    rfft: bool,
+    fftshift: bool = False,
+    device: torch.device | None = None,
+) -> torch.Tensor:
+    # generate 1d grid of DFT sample frequencies, shape (w, 1)
+    w = image_shape[-1:]
+    grid = (
+        torch.fft.rfftfreq(w, device=device)
+        if rfft
+        else torch.fft.fftfreq(w, device=device)
+    )
+
+    # get grid of same shape with all zeros, append as third coordinate
+    if rfft is True:
+        zeros = torch.zeros(size=rfft_shape((w,)), dtype=grid.dtype, device=device)
+    else:
+        zeros = torch.zeros(size=(w,), dtype=grid.dtype, device=device)
+    central_slice_grid, _ = einops.pack([zeros, grid], pattern='w *')  # (w, 2)
+
+    # fftshift if requested
+    if fftshift is True:
+        central_slice_grid = einops.rearrange(central_slice_grid, 'w freq -> freq w')
+        central_slice_grid = fftshift_1d(central_slice_grid, rfft=rfft)
+        central_slice_grid = einops.rearrange(central_slice_grid, 'freq w -> w freq')
+    return central_slice_grid

--- a/src/torch_fourier_slice/grids/central_line_fftfreq_grid.py
+++ b/src/torch_fourier_slice/grids/central_line_fftfreq_grid.py
@@ -11,7 +11,7 @@ def central_line_fftfreq_grid(
     device: torch.device | None = None,
 ) -> torch.Tensor:
     # generate 1d grid of DFT sample frequencies, shape (w, 1)
-    w = image_shape[-1:]
+    w, = image_shape[-1:]
     grid = (
         torch.fft.rfftfreq(w, device=device)
         if rfft

--- a/src/torch_fourier_slice/project.py
+++ b/src/torch_fourier_slice/project.py
@@ -2,7 +2,7 @@ import torch
 import torch.nn.functional as F
 from torch_grid_utils import fftfreq_grid
 
-from .slice_extraction import extract_central_slices_rfft_3d
+from .slice_extraction import extract_central_lines_rfft_2d, extract_central_slices_rfft_3d
 
 
 def project_3d_to_2d(
@@ -66,4 +66,68 @@ def project_3d_to_2d(
     # unpad if required
     if pad is True:
         projections = projections[..., pad_length:-pad_length, pad_length:-pad_length]
+    return torch.real(projections)
+
+
+def project_2d_to_1d(
+    image: torch.Tensor,
+    rotation_matrices: torch.Tensor,
+    pad: bool = True,
+    fftfreq_max: float | None = None,
+) -> torch.Tensor:
+    """Project a cubic volume by sampling a central slice through its DFT.
+
+    Parameters
+    ----------
+    image: torch.Tensor
+        `(d, d)` volume.
+    rotation_matrices: torch.Tensor
+        `(..., 2, 2)` array of rotation matrices for insertion of `images`.
+        Rotation matrices left-multiply column vectors containing xyz coordinates.
+    pad: bool
+        Whether to pad the volume 2x with zeros to increase sampling rate in the DFT.
+    fftfreq_max: float | None
+        Maximum frequency (cycles per pixel) included in the projection.
+
+    Returns
+    -------
+    projections: torch.Tensor
+        `(..., d)` array of projection images.
+    """
+    # padding
+    if pad is True:
+        pad_length = image.shape[-1] // 2
+        image = F.pad(image, pad=[pad_length] * 4, mode='constant', value=0)
+
+    # premultiply by sinc2
+    grid = fftfreq_grid(
+        image_shape=image.shape,
+        rfft=False,
+        fftshift=True,
+        norm=True,
+        device=image.device
+    )
+    image = image * torch.sinc(grid) ** 2
+
+    # calculate DFT
+    dft = torch.fft.fftshift(image, dim=(-2, -1))  # volume center to array origin
+    dft = torch.fft.rfftn(dft, dim=(-2, -1))
+    dft = torch.fft.fftshift(dft, dim=(-2,))  # actual fftshift of 2D rfft
+
+    # make projections by taking central slices
+    projections = extract_central_lines_rfft_2d(
+        image_rfft=dft,
+        image_shape=image.shape,
+        rotation_matrices=rotation_matrices,
+        fftfreq_max=fftfreq_max
+    )  # (..., h, w) rfft stack
+
+    # transform back to real space
+    # projections = torch.fft.ifftshift(projections, dim=(-2,))  Not needed for 1D
+    projections = torch.fft.irfftn(projections, dim=(-1))
+    projections = torch.fft.ifftshift(projections, dim=(-1))  # recenter 2D image in real space
+
+    # unpad if required
+    if pad is True:
+        projections = projections[..., pad_length:-pad_length]
     return torch.real(projections)

--- a/src/torch_fourier_slice/project.py
+++ b/src/torch_fourier_slice/project.py
@@ -2,7 +2,7 @@ import torch
 import torch.nn.functional as F
 from torch_grid_utils import fftfreq_grid
 
-from .slice_extraction import extract_central_lines_rfft_2d, extract_central_slices_rfft_3d
+from .slice_extraction import extract_central_slices_rfft_2d, extract_central_slices_rfft_3d
 
 
 def project_3d_to_2d(
@@ -115,7 +115,7 @@ def project_2d_to_1d(
     dft = torch.fft.fftshift(dft, dim=(-2,))  # actual fftshift of 2D rfft
 
     # make projections by taking central slices
-    projections = extract_central_lines_rfft_2d(
+    projections = extract_central_slices_rfft_2d(
         image_rfft=dft,
         image_shape=image.shape,
         rotation_matrices=rotation_matrices,

--- a/src/torch_fourier_slice/slice_extraction/__init__.py
+++ b/src/torch_fourier_slice/slice_extraction/__init__.py
@@ -1,2 +1,2 @@
-from ._extract_central_slices_rfft_2d import extract_central_slices_rfft_2d
+from ._extract_central_lines_rfft_2d import extract_central_lines_rfft_2d
 from ._extract_central_slices_rfft_3d import extract_central_slices_rfft_3d

--- a/src/torch_fourier_slice/slice_extraction/__init__.py
+++ b/src/torch_fourier_slice/slice_extraction/__init__.py
@@ -1,2 +1,2 @@
-from ._extract_central_lines_rfft_2d import extract_central_lines_rfft_2d
+from ._extract_central_slices_rfft_2d import extract_central_slices_rfft_2d
 from ._extract_central_slices_rfft_3d import extract_central_slices_rfft_3d

--- a/src/torch_fourier_slice/slice_extraction/__init__.py
+++ b/src/torch_fourier_slice/slice_extraction/__init__.py
@@ -1,1 +1,2 @@
 from ._extract_central_slices_rfft_3d import extract_central_slices_rfft_3d
+from ._extract_central_slices_rfft_2d import extract_central_slices_rfft_2d

--- a/src/torch_fourier_slice/slice_extraction/__init__.py
+++ b/src/torch_fourier_slice/slice_extraction/__init__.py
@@ -1,2 +1,2 @@
-from ._extract_central_slices_rfft_3d import extract_central_slices_rfft_3d
 from ._extract_central_slices_rfft_2d import extract_central_slices_rfft_2d
+from ._extract_central_slices_rfft_3d import extract_central_slices_rfft_3d

--- a/src/torch_fourier_slice/slice_extraction/_extract_central_lines_rfft_2d.py
+++ b/src/torch_fourier_slice/slice_extraction/_extract_central_lines_rfft_2d.py
@@ -6,7 +6,7 @@ from ..dft_utils import fftfreq_to_dft_coordinates
 from ..grids.central_line_fftfreq_grid import central_line_fftfreq_grid
 
 
-def extract_central_slices_rfft_2d(
+def extract_central_lines_rfft_2d(
     image_rfft: torch.Tensor,
     image_shape: tuple[int, int],
     rotation_matrices: torch.Tensor,  # (..., 2, 2)
@@ -23,7 +23,7 @@ def extract_central_slices_rfft_2d(
 
     # keep track of some shapes
     stack_shape = tuple(rotation_matrices.shape[:-2])
-    rfft_shape = freq_grid.shape[-2]
+    rfft_shape = (freq_grid.shape[-2],)
     output_shape = (*stack_shape, *rfft_shape)
 
     # get (b, 2, 1) array of yx coordinates to rotate
@@ -57,7 +57,7 @@ def extract_central_slices_rfft_2d(
     rotated_coords = einops.rearrange(rotated_coords, "... b yx 1 -> ... b yx")
 
     # flip coordinates that ended up in redundant half transform after rotation
-    conjugate_mask = rotated_coords[..., 2] < 0
+    conjugate_mask = rotated_coords[..., 1] < 0
     rotated_coords[conjugate_mask, ...] *= -1
 
     # convert frequencies to array coordinates in fftshifted DFT

--- a/src/torch_fourier_slice/slice_extraction/_extract_central_slices_rfft_2d.py
+++ b/src/torch_fourier_slice/slice_extraction/_extract_central_slices_rfft_2d.py
@@ -6,7 +6,7 @@ from ..dft_utils import fftfreq_to_dft_coordinates
 from ..grids.central_line_fftfreq_grid import central_line_fftfreq_grid
 
 
-def extract_central_lines_rfft_2d(
+def extract_central_slices_rfft_2d(
     image_rfft: torch.Tensor,
     image_shape: tuple[int, int],
     rotation_matrices: torch.Tensor,  # (..., 2, 2)

--- a/src/torch_fourier_slice/slice_extraction/_extract_central_slices_rfft_2d.py
+++ b/src/torch_fourier_slice/slice_extraction/_extract_central_slices_rfft_2d.py
@@ -1,0 +1,83 @@
+import torch
+import einops
+from torch_image_lerp import sample_image_2d
+
+from ..dft_utils import fftfreq_to_dft_coordinates
+from ..grids.central_slice_fftfreq_grid import central_line_fftfreq_grid
+
+
+def extract_central_slices_rfft_2d(
+    image_rfft: torch.Tensor,
+    image_shape: tuple[int, int],
+    rotation_matrices: torch.Tensor,  # (..., 2, 2)
+    fftfreq_max: float | None = None,
+) -> torch.Tensor:
+    """Extract central slice from an fftshifted rfft."""
+    # generate grid of DFT sample frequencies for a central slice spanning the x-plane
+    freq_grid = central_line_fftfreq_grid(
+        image_shape=image_shape,
+        rfft=True,
+        fftshift=True,
+        device=image_rfft.device,
+    )  # (w, 2) yx coords
+
+    # keep track of some shapes
+    stack_shape = tuple(rotation_matrices.shape[:-2])
+    rfft_shape = freq_grid.shape[-2]
+    output_shape = (*stack_shape, *rfft_shape)
+
+    # get (b, 2, 1) array of yx coordinates to rotate
+    if fftfreq_max is not None:
+        normed_grid = einops.reduce(freq_grid ** 2, 'w yx -> w', reduction='sum') ** 0.5
+        freq_grid_mask = normed_grid <= fftfreq_max
+        valid_coords = freq_grid[freq_grid_mask, ...]  # (b, yx)
+    else:
+        valid_coords = einops.rearrange(freq_grid, 'w yx -> (w) yx')
+    valid_coords = einops.rearrange(valid_coords, 'b yx -> b yx 1')
+
+    # rotation matrices rotate xyz coordinates, make them rotate zyx coordinates
+    # xyz:
+    # [a b c] [x]    [ax + by + cz]
+    # [d e f] [y]  = [dx + ey + fz]
+    # [g h i] [z]    [gx + hy + iz]
+    #
+    # zyx:
+    # [i h g] [z]    [gx + hy + iz]
+    # [f e d] [y]  = [dx + ey + fz]
+    # [c b a] [x]    [ax + by + cz]
+    rotation_matrices = torch.flip(rotation_matrices, dims=(-2, -1))
+
+    # add extra dim to rotation matrices for broadcasting
+    rotation_matrices = einops.rearrange(rotation_matrices, '... i j -> ... 1 i j')
+
+    # rotate all valid coordinates by each rotation matrix
+    rotated_coords = rotation_matrices @ valid_coords  # (..., b, yx, 1)
+
+    # remove last dim of size 1
+    rotated_coords = einops.rearrange(rotated_coords, '... b yx 1 -> ... b yx')
+
+    # flip coordinates that ended up in redundant half transform after rotation
+    conjugate_mask = rotated_coords[..., 2] < 0
+    rotated_coords[conjugate_mask, ...] *= -1
+
+    # convert frequencies to array coordinates in fftshifted DFT
+    rotated_coords = fftfreq_to_dft_coordinates(
+        frequencies=rotated_coords,
+        image_shape=image_shape,
+        rfft=True
+    )  # (...) rfft
+    samples = sample_image_2d(image=image_rfft, coordinates=rotated_coords)
+
+    # take complex conjugate of values from redundant half transform
+    samples[conjugate_mask] = torch.conj(samples[conjugate_mask])
+
+    # insert samples back into DFTs
+    projection_image_dfts = torch.zeros(output_shape, device=image_rfft.device,
+                                        dtype=image_rfft.dtype)
+    if fftfreq_max is None:
+        freq_grid_mask = torch.ones(size=rfft_shape, dtype=torch.bool,
+                                    device=image_rfft.device)
+
+    projection_image_dfts[..., freq_grid_mask] = samples
+
+    return projection_image_dfts

--- a/src/torch_fourier_slice/slice_extraction/_extract_central_slices_rfft_2d.py
+++ b/src/torch_fourier_slice/slice_extraction/_extract_central_slices_rfft_2d.py
@@ -28,11 +28,10 @@ def extract_central_slices_rfft_2d(
 
     # get (b, 2, 1) array of yx coordinates to rotate
     if fftfreq_max is not None:
-        normed_grid = einops.reduce(freq_grid**2, "w yx -> w", reduction="sum") ** 0.5
-        freq_grid_mask = normed_grid <= fftfreq_max
-        valid_coords = freq_grid[freq_grid_mask, ...]  # (b, yx)
+        freq_grid_mask = freq_grid <= fftfreq_max
+        valid_coords = freq_grid[freq_grid_mask, ...]
     else:
-        valid_coords = einops.rearrange(freq_grid, "w yx -> (w) yx")
+        valid_coords = freq_grid
     valid_coords = einops.rearrange(valid_coords, "b yx -> b yx 1")
 
     # rotation matrices rotate xyz coordinates, make them rotate zyx coordinates

--- a/tests/test_torch_fourier_slice.py
+++ b/tests/test_torch_fourier_slice.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from torch_fourier_slice import project_3d_to_2d, backproject_2d_to_3d
+from torch_fourier_slice import project_3d_to_2d, project_2d_to_1d, backproject_2d_to_3d
 from torch_fourier_shell_correlation import fsc
 from scipy.stats import special_ortho_group
 
@@ -23,6 +23,24 @@ def test_project_3d_to_2d_rotation_center():
         max = torch.argmax(image)
         i, j = divmod(max.item(), 32)
         assert (i, j) == (16, 16)
+
+
+def test_project_2d_to_1d_rotation_center():
+    # rotation center should be at position of DC in DFT
+    image = torch.zeros((32, 32))
+    image[16, 16] = 1
+
+    # make projections
+    rotation_matrices = torch.tensor(special_ortho_group.rvs(dim=2, size=100)).float()
+    projections = project_2d_to_1d(
+        image=image,
+        rotation_matrices=rotation_matrices,
+    )
+
+    # check max is always at (16), implying point (16) never moves
+    for image in projections:
+        i = torch.argmax(image)
+        assert i == 16
 
 
 def test_3d_2d_projection_backprojection_cycle(cube):


### PR DESCRIPTION
I worked on the 2D to 1D Fourier slice extraction, which is functional (I tried it for tttsa, see teamtomo/tttsa#19). 

One thing that I haven't figured out is a 90 degrees addition to the in plane rotations for the rotation matrices for this function, compared to the affine transform I used before ([link to the line of code](https://github.com/McHaillet/tttsa/blob/1b91814033a12fb346894d968a56f01256bec3a8/src/tttsa/optimizers.py#L99)). One of the two is interpreting it wrongly.

The dft_center also needed a fix to run on GPU, I can also put that in a separate PR if you are not sure yet about this one and want that bug fix in.

I have not added the inverse operation of 1D to 2D slice insertion. Should that be added here as well?