### PR TITLE
add zyx_matrix_order/yx_matrix_order to keyword arguments 

### DIFF
--- a/src/torch_fourier_slice/backproject.py
+++ b/src/torch_fourier_slice/backproject.py
@@ -10,7 +10,7 @@ def backproject_2d_to_3d(
     rotation_matrices: torch.Tensor,  # (b, 3, 3)
     pad: bool = True,
     fftfreq_max: float | None = None,
-    zyx_matrix_order: bool = False,
+    zyx_matrices: bool = False,
 ):
     """Perform a 3D reconstruction from a set of 2D projection images.
 
@@ -25,8 +25,9 @@ def backproject_2d_to_3d(
         Whether to pad the input images 2x (`True`) or not (`False`).
     fftfreq_max: float | None
         Maximum frequency (cycles per pixel) included in the projection.
-    zyx_matrix_order: bool
-        Set to True if the provided matrices operate on zyx coordinates instead of xyz.
+    zyx_matrices: bool
+        Set to True if the provided matrices left multiply zyx column vectors
+        instead of xyz column vectors.
 
     Returns
     -------
@@ -55,7 +56,7 @@ def backproject_2d_to_3d(
         volume_shape=volume_shape,
         rotation_matrices=rotation_matrices,
         fftfreq_max=fftfreq_max,
-        zyx_matrix_order=zyx_matrix_order,
+        zyx_matrices=zyx_matrices,
     )
 
     # reweight reconstruction

--- a/src/torch_fourier_slice/project.py
+++ b/src/torch_fourier_slice/project.py
@@ -10,7 +10,7 @@ def project_3d_to_2d(
     rotation_matrices: torch.Tensor,
     pad: bool = True,
     fftfreq_max: float | None = None,
-    zyx_matrix_order: bool = False,
+    zyx_matrices: bool = False,
 ) -> torch.Tensor:
     """Project a cubic volume by sampling a central slice through its DFT.
 
@@ -25,8 +25,9 @@ def project_3d_to_2d(
         Whether to pad the volume 2x with zeros to increase sampling rate in the DFT.
     fftfreq_max: float | None
         Maximum frequency (cycles per pixel) included in the projection.
-    zyx_matrix_order: bool
-        Set to True if the provided matrices operate on zyx coordinates instead of xyz.
+    zyx_matrices: bool
+        Set to True if the provided matrices left multiply zyx column vectors
+        instead of xyz column vectors.
 
     Returns
     -------
@@ -59,7 +60,7 @@ def project_3d_to_2d(
         image_shape=volume.shape,
         rotation_matrices=rotation_matrices,
         fftfreq_max=fftfreq_max,
-        zyx_matrix_order=zyx_matrix_order,
+        zyx_matrices=zyx_matrices,
     )  # (..., h, w) rfft stack
 
     # transform back to real space
@@ -127,7 +128,7 @@ def project_2d_to_1d(
         image_shape=image.shape,
         rotation_matrices=rotation_matrices,
         fftfreq_max=fftfreq_max,
-        yx_matrix_order=yx_matrix_order,
+        yx_matrices=yx_matrix_order,
     )  # (..., w) rfft stack
 
     # transform back to real space

--- a/src/torch_fourier_slice/slice_extraction/_extract_central_slices_rfft_2d.py
+++ b/src/torch_fourier_slice/slice_extraction/_extract_central_slices_rfft_2d.py
@@ -11,7 +11,7 @@ def extract_central_slices_rfft_2d(
     image_shape: tuple[int, int],
     rotation_matrices: torch.Tensor,  # (..., 2, 2)
     fftfreq_max: float | None = None,
-    yx_matrix_order: bool = False,
+    yx_matrices: bool = False,
 ) -> torch.Tensor:
     """Extract central slice from an fftshifted rfft."""
     # generate grid of DFT sample frequencies for a central slice spanning the x-plane
@@ -32,18 +32,19 @@ def extract_central_slices_rfft_2d(
         freq_grid_mask = freq_grid <= fftfreq_max
         valid_coords = freq_grid[freq_grid_mask, ...]
     else:
+        freq_grid_mask = torch.ones(size=rfft_shape, dtype=torch.bool, device=image_rfft.device)
         valid_coords = freq_grid
     valid_coords = einops.rearrange(valid_coords, "b yx -> b yx 1")
 
     # rotation matrices rotate xyz coordinates, make them rotate zyx coordinates
     # xy:
-    # [a b] [x]    [ax + by]
-    # [d e] [y]  = [dx + ey]
+    # [a b] [x]   [ax + by]   [x']
+    # [c d] [y] = [cx + dy] = [y']
     #
     # yx:
-    # [e d] [y]  = [dx + ey]
-    # [b a] [x]    [ax + by]
-    if not yx_matrix_order:
+    # [d c] [y]   [cx + dy]   [y']
+    # [b a] [x] = [ax + by] = [x']
+    if not yx_matrices:
         rotation_matrices = torch.flip(rotation_matrices, dims=(-2, -1))
 
     # add extra dim to rotation matrices for broadcasting
@@ -74,11 +75,6 @@ def extract_central_slices_rfft_2d(
     projection_image_dfts = torch.zeros(
         output_shape, device=image_rfft.device, dtype=image_rfft.dtype
     )
-    if fftfreq_max is None:
-        freq_grid_mask = torch.ones(
-            size=rfft_shape, dtype=torch.bool, device=image_rfft.device
-        )
-
     projection_image_dfts[..., freq_grid_mask] = samples
 
     return projection_image_dfts

--- a/src/torch_fourier_slice/slice_insertion/_insert_central_slices_rfft_3d.py
+++ b/src/torch_fourier_slice/slice_insertion/_insert_central_slices_rfft_3d.py
@@ -11,7 +11,7 @@ def insert_central_slices_rfft_3d(
     volume_shape: tuple[int, int, int],
     rotation_matrices: torch.Tensor,
     fftfreq_max: float | None = None,
-    zyx_matrix_order: bool = False,
+    zyx_matrices: bool = False,
 ):
     # generate grid of DFT sample frequencies for a central slice spanning the xy-plane
     freq_grid = central_slice_fftfreq_grid(
@@ -44,7 +44,7 @@ def insert_central_slices_rfft_3d(
     # [i h g] [z]    [gx + hy + iz]
     # [f e d] [y]  = [dx + ey + fz]
     # [c b a] [x]    [ax + by + cz]
-    if not zyx_matrix_order:
+    if not zyx_matrices:
         rotation_matrices = torch.flip(rotation_matrices, dims=(-2, -1))
 
     # add extra dim to rotation matrices for broadcasting


### PR DESCRIPTION
Closes #9

Added the keyword argument for matrices that work on zyx or yx coordinates; hence the internal matrix flip is not required. Would appreciate if you could check that I did not miss anything!