### PR TITLE
current torch-image-interpolation main not working

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ source = "vcs"
 only-include = ["src"]
 sources = ["src"]
 
+[tool.hatch.metadata]
+allow-direct-references = true
+
 # https://peps.python.org/pep-0621/
 [project]
 name = "torch-fourier-slice"
@@ -37,7 +40,8 @@ dependencies = [
     "torch",
     "numpy",
     "einops",
-    "torch_image_interpolation>=0.0.6",
+    # "torch_image_interpolation>=0.0.6",
+    "torch-image-interpolation @ git+https://github.com/teamtomo/torch-image-interpolation@main",
     "torch_grid_utils",
 ]
 
@@ -109,6 +113,7 @@ ignore = [
 [tool.ruff.format]
 docstring-code-format = true
 skip-magic-trailing-comma = false  # default is false
+quote-style = "single"  # Prefer single quotes over double quotes.
 
 # https://mypy.readthedocs.io/en/stable/config_file.html
 [tool.mypy]


### PR DESCRIPTION
I was looking into updating torch-fourier-slice for batching. For that I need the latest main updates from torch-image-interpolation, as you added the channel dimension for that. However, just installing main from there ran me into some issues--see failing tests and a detailed report below. The error is a bit unclear to me, do you have some input @alisterburt ?

This PR did not update any of the code just the dependency -- its just a draft to illustrate the problem.


