### PR TITLE
fix typing issues with torch-image-interpolation

### DIFF
--- a/src/torch_fourier_slice/slice_extraction/_extract_central_slices_rfft_2d.py
+++ b/src/torch_fourier_slice/slice_extraction/_extract_central_slices_rfft_2d.py
@@ -14,6 +14,8 @@ def extract_central_slices_rfft_2d(
     yx_matrices: bool = False,
 ) -> torch.Tensor:
     """Extract central slice from an fftshifted rfft."""
+    rotation_matrices = rotation_matrices.to(torch.float32)
+
     # generate grid of DFT sample frequencies for a central slice spanning the x-plane
     freq_grid = _central_line_fftfreq_grid(
         image_shape=image_shape,

--- a/src/torch_fourier_slice/slice_extraction/_extract_central_slices_rfft_3d.py
+++ b/src/torch_fourier_slice/slice_extraction/_extract_central_slices_rfft_3d.py
@@ -14,6 +14,8 @@ def extract_central_slices_rfft_3d(
     zyx_matrices: bool = False,
 ) -> torch.Tensor:
     """Extract central slice from an fftshifted rfft."""
+    rotation_matrices = rotation_matrices.to(torch.float32)
+
     # generate grid of DFT sample frequencies for a central slice spanning the xy-plane
     freq_grid = _central_slice_fftfreq_grid(
         volume_shape=image_shape,

--- a/tests/test_torch_fourier_slice.py
+++ b/tests/test_torch_fourier_slice.py
@@ -64,14 +64,14 @@ def test_3d_2d_projection_backprojection_cycle(cube):
 
 
 @pytest.mark.parametrize(
-    "images, rotation_matrices",
-    [
-        (
-            torch.rand((10, 28, 28)).float(),
-            torch.tensor(special_ortho_group.rvs(dim=3, size=10)).float(),
-        ),
-    ],
+    "dtype",
+    [torch.float32, torch.float64],
 )
-def test_dtypes_slice_insertion(images, rotation_matrices):
+def test_dtypes_slice_insertion(dtype):
+    images = torch.rand((10, 28, 28), dtype=dtype)
+    rotation_matrices = torch.tensor(
+        special_ortho_group.rvs(dim=3, size=10),
+        dtype=dtype,
+    )
     result = backproject_2d_to_3d(images, rotation_matrices)
-    assert result.dtype == torch.float64
+    assert result.dtype == dtype


### PR DESCRIPTION
updates:
* added line to always convert rotation matrix to float32 to prevent multiplication error with coordinate grid
* ensure output tensor passed to image-interpolation has the same dtype as input
* adapts weights tensor to use float32 or float64 depending on the ft dtype
* updated tests to check for function input output dtype consistency